### PR TITLE
クイズクリア後に魚の画像を表示させる

### DIFF
--- a/intern-quiz/src/app/pages/quiz/quiz.component.ts
+++ b/intern-quiz/src/app/pages/quiz/quiz.component.ts
@@ -73,7 +73,8 @@ export class QuizComponent implements OnInit {
         const randomFish = selectedFishItem.attributes;
         this.selectedFish = {
           ...randomFish,
-          id: selectedFishItem.id
+          id: selectedFishItem.id,
+          image: selectedFishItem.fishPictureUrl
       };
         console.log('クイズの答え', randomFish.fishName); 
         this.loadQuestions();
@@ -137,7 +138,7 @@ export class QuizComponent implements OnInit {
   }
   UserAnswer(): void {
     if (this.userAnswer === this.selectedFish.fishName) {
-        this.resultImage = '/assets/kozakana_ao_correct.png';
+        this.resultImage = this.selectedFish.fishPictureUrl;
         this.quizForm.patchValue({
             fishguide: this.selectedFish.id,
             scoreMin: this.scoreMin,


### PR DESCRIPTION
## Checklist for Developer
- [x] 最新のdevelopブランチをPullした。Pulled the latest develop branch.
  - できない理由 Reason not to do: 
- [x] Pull RequestをIssueに紐付けた。Connected with the issue.
- [x] 自分をAssignした。Assigned yourself.
- [x] レビュワーを指定した。Assigned reviewer.

## 📝 そのほかの関連するIssue / Related issues other than connected one
<!-- ZenHubで紐付けられなかったIssueの番号を記載 -->
<!-- List down issue numbers which could not be connected with ZenHub -->
- #0
- #0

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
クイズにクリアした時に写真を表示させました
（
写真サイズの統一化や、
クイズにクリアしたのかわかりずらいという問題点もあるので別のissueに追加して改善したいです
）

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="1273" alt="スクリーンショット 2024-09-02 3 03 11" src="https://github.com/user-attachments/assets/b08e19ca-557c-4a05-b519-613860a066e7">


## レビューするポイント (Points for review):
<!-- テストケースを箇条書きで。Issueに書いてあればコピーしてください。 -->
<!-- List down test cases for this PR. Or you can copy that from the issue. -->
クイズにクリアした時に写真を表示させました
（
写真サイズの統一化や、
クイズにクリアしたのかわかりずらいという問題点もあるので別のissueに追加して改善したいです
）